### PR TITLE
is_succeed函数增加对code字段的判断

### DIFF
--- a/ragflows/api.py
+++ b/ragflows/api.py
@@ -129,4 +129,5 @@ def parse_chunks_with_check(filename):
     
 # 是否请求成功
 def is_succeed(response):
-    return response.get("retcode") == 0
+    # 20250208：增加对code字段的判断，因为新版ragflow返回字段名由retcode改为code了，保留retcode兼容旧版ragflow
+    return response.get("retcode") == 0 or response.get("code") == 0


### PR DESCRIPTION
`is_succeed`函数增加对code字段的判断，因为`新版ragflow`返回字段名由`retcode`改为`code`了，保留`retcode`兼容旧版`ragflow`

![image](https://github.com/user-attachments/assets/9db00c42-2ef1-44dd-bf90-2269c5417438)

相关Issues：#5 